### PR TITLE
fix(timeline): auto-advance pages when filter hides every card

### DIFF
--- a/packages/oh-my-old-tweet/src/Timeline.tsx
+++ b/packages/oh-my-old-tweet/src/Timeline.tsx
@@ -133,6 +133,7 @@ function Timeline1({ user }: { user: string }) {
   const { showBoundary }    = useErrorBoundary();
   const page                = useRef(0);
   const pageSize            = 30;
+  const containerRef        = useRef<HTMLDivElement | null>(null);
 
   const [profiles, setProfiles]             = useState<User[]>([]);
   const [currentProfileIndex, setCurrentProfileIndex] = useState(0);
@@ -159,7 +160,7 @@ function Timeline1({ user }: { user: string }) {
     setLst(lst => init ? l : lst.concat(l));
   }, [user]);
 
-  const fetchData = (init: boolean) => {
+  const fetchData = useCallback((init: boolean) => {
     if (init) page.current = 0;
     if (!cdxList.current) return;
     const pageNow = page.current;
@@ -170,7 +171,7 @@ function Timeline1({ user }: { user: string }) {
       page.current += 1;
       updateLst(nextData, init);
     }
-  };
+  }, [updateLst]);
 
   const { tweetFilter: { dateInRange } } = useContext(FilterContext);
 
@@ -191,6 +192,34 @@ function Timeline1({ user }: { user: string }) {
       void profile; // suppress unused warning
     }
   }, [profiles, currentProfileIndex]);
+
+  // If the current page leaves nothing visible (every card collapsed by
+  // the filter, or the list is shorter than the viewport), InfiniteScroll's
+  // scroll-bottom trigger never fires and the user sees an empty page that
+  // never advances. Watch the container and pull the next page when it fits
+  // entirely within the viewport.
+  useEffect(() => {
+    if (!hasMore || cdxLoading) return;
+    const node = containerRef.current;
+    if (!node) return;
+
+    let cancelled = false;
+    const check = () => {
+      if (cancelled) return;
+      const rect = node.getBoundingClientRect();
+      if (rect.bottom <= window.innerHeight) fetchData(false);
+    };
+
+    const raf = requestAnimationFrame(check);
+    const ro = typeof ResizeObserver !== 'undefined' ? new ResizeObserver(check) : null;
+    ro?.observe(node);
+
+    return () => {
+      cancelled = true;
+      cancelAnimationFrame(raf);
+      ro?.disconnect();
+    };
+  }, [lst.length, hasMore, cdxLoading, fetchData]);
 
   const currentProfile = profiles.length > 0 ? profiles[currentProfileIndex] : null;
 
@@ -218,7 +247,7 @@ function Timeline1({ user }: { user: string }) {
   }
 
   return (
-    <div className="max-w-4xl mx-auto px-4 py-6">
+    <div ref={containerRef} className="max-w-4xl mx-auto px-4 py-6">
       {/* Profile banner (visible on all screen sizes, top of page) */}
       {currentProfile && (
         <div className="mb-6">

--- a/packages/oh-my-old-tweet/tests/unit/Timeline.test.tsx
+++ b/packages/oh-my-old-tweet/tests/unit/Timeline.test.tsx
@@ -1,0 +1,170 @@
+import React from 'react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { render, cleanup, screen, waitFor } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import { DateTime, Interval } from 'luxon';
+import type { Post } from 'twitter-data-parser';
+import { ConfigContext } from '../../src/context/ConfigContext';
+import { FilterContext } from '../../src/context/FilterContext';
+import type { TweetFilter } from '../../src/context/FilterContext';
+import { defaultConfig } from '../../src/corsUrl';
+
+// State shared between vi.mock factories and the test bodies. vi.hoisted is
+// the supported way to do this — plain top-level `let` would be hoisted AFTER
+// the mocks and read as undefined inside the factory closures.
+const { mockPostMap, mockCdxList, infiniteScrollState } = vi.hoisted(() => ({
+  mockPostMap: new Map<string, Post>(),
+  mockCdxList: { fn: undefined as unknown as ReturnType<typeof vi.fn> },
+  infiniteScrollState: { props: null as null | Record<string, unknown> },
+}));
+
+vi.mock('../../src/Data', async () => {
+  const actual = await vi.importActual<typeof import('../../src/Data')>('../../src/Data');
+  return {
+    ...actual,
+    getCdxList: (...args: unknown[]) => mockCdxList.fn(...args),
+  };
+});
+
+// useCachedFetch normally pulls from IDB / archive.org. Replace with a sync
+// mock that mirrors the real dependency contract: re-fires when `setData`
+// identity changes (which is what happens when tweetFilter changes upstream).
+vi.mock('../../src/useCachedFetch', async () => {
+  const ReactMod = await import('react');
+  return {
+    default: (cdxItem: { id: string }, setData: (p: Post | boolean) => void) => {
+      ReactMod.useEffect(() => {
+        const post = mockPostMap.get(cdxItem.id);
+        setData(post == null ? false : post);
+      }, [cdxItem, setData]);
+    },
+  };
+});
+
+// TCard pulls in react-tweet-card. Stub it out to a marker.
+vi.mock('../../src/TCard', () => ({
+  TCard: ({ p }: { p: Post }) => (
+    <div data-testid="tcard">{p.user.userName}:{p.id}</div>
+  ),
+}));
+
+// Capture InfiniteScroll props so we can assert hasMore/dataLength directly.
+vi.mock('react-infinite-scroll-component', async () => {
+  const ReactMod = await import('react');
+  return {
+    default: (props: Record<string, unknown> & { children?: React.ReactNode }) => {
+      infiniteScrollState.props = props;
+      return ReactMod.createElement(
+        'div',
+        { 'data-testid': 'infinite-scroll' },
+        props.children,
+      );
+    },
+  };
+});
+
+function makeCdxItem(id: string, dateIso: string) {
+  return { id, original: `https://twitter.com/foo/status/${id}`, date: new Date(dateIso) };
+}
+
+function makePost(id: string, opts: { user?: string; isReply?: boolean } = {}): Post {
+  const userName = opts.user ?? 'foo';
+  return {
+    id,
+    user: { userName, fullName: userName, avatar: '' },
+    text: `tweet ${id}`,
+    date: new Date('2020-06-01'),
+    images: [],
+    tweetUrl: `https://twitter.com/${userName}/status/${id}`,
+    archiveUrl: '',
+    ...(opts.isReply
+      ? { replyInfo: { targetUser: { userName: 'bar' } } }
+      : {}),
+  };
+}
+
+const baseFilter: TweetFilter = {
+  contentBelongTo: ['post', 'reply'],
+  mustContainImage: false,
+  dateInRange: Interval.fromDateTimes(DateTime.fromISO('2006-01-01'), DateTime.now()),
+};
+
+function Wrap({ filter, children }: { filter: TweetFilter; children: React.ReactNode }) {
+  return (
+    <ConfigContext.Provider value={{ config: defaultConfig, setConfig: vi.fn() }}>
+      <FilterContext.Provider value={{ tweetFilter: filter, setTweetFilter: vi.fn() }}>
+        <MemoryRouter>{children}</MemoryRouter>
+      </FilterContext.Provider>
+    </ConfigContext.Provider>
+  );
+}
+
+beforeEach(() => {
+  mockPostMap.clear();
+  mockCdxList.fn = vi.fn();
+  infiniteScrollState.props = null;
+});
+
+afterEach(cleanup);
+
+describe('Timeline — subtle filter/scroll behaviour', () => {
+  it('auto-advances pages when the filter hides every card so the user is never stuck on an empty page', async () => {
+    // 60 cdx items → 2 pages of 30. Every fetched post is a reply.
+    // Filter excludes replies → every loaded card collapses to null.
+    // Without the auto-advance fix, InfiniteScroll's scroll-bottom trigger
+    // never fires (no scrollable content) and the user is stuck. The fix
+    // walks pages until the cdx list is exhausted.
+    const items = Array.from({ length: 60 }, (_, i) => makeCdxItem(`r${i}`, '2020-06-01'));
+    items.forEach(it => mockPostMap.set(it.id, makePost(it.id, { isReply: true })));
+    mockCdxList.fn.mockResolvedValue(items);
+
+    const filter: TweetFilter = { ...baseFilter, contentBelongTo: ['post'] };
+    const { Timeline } = await import('../../src/Timeline');
+
+    render(<Wrap filter={filter}><Timeline user="foo" /></Wrap>);
+
+    // Eventually every cdx item is mounted and InfiniteScroll knows there's
+    // nothing left to fetch. (jsdom reports zero-height layout, which is the
+    // same "page fits in viewport" condition that triggers the auto-advance.)
+    await waitFor(() => {
+      expect(infiniteScrollState.props).not.toBeNull();
+      expect(infiniteScrollState.props!.dataLength).toBe(60);
+      expect(infiniteScrollState.props!.hasMore).toBe(false);
+    });
+
+    // Filter still excludes everything → no visible tweet cards.
+    expect(screen.queryAllByTestId('tcard')).toHaveLength(0);
+  });
+
+  it('changing tweetFilter re-evaluates already-loaded LoadableTCards', async () => {
+    const items = [
+      makeCdxItem('p1', '2020-01-01'),
+      makeCdxItem('r1', '2020-02-01'),
+      makeCdxItem('p2', '2020-03-01'),
+      makeCdxItem('r2', '2020-04-01'),
+    ];
+    mockPostMap.set('p1', makePost('p1'));
+    mockPostMap.set('r1', makePost('r1', { isReply: true }));
+    mockPostMap.set('p2', makePost('p2'));
+    mockPostMap.set('r2', makePost('r2', { isReply: true }));
+    mockCdxList.fn.mockResolvedValue(items);
+
+    const { Timeline } = await import('../../src/Timeline');
+
+    const { rerender } = render(
+      <Wrap filter={baseFilter}><Timeline user="foo" /></Wrap>,
+    );
+
+    // Initial filter allows post + reply → all 4 cards visible.
+    await waitFor(() => expect(screen.queryAllByTestId('tcard')).toHaveLength(4));
+
+    // Tighten filter to posts only. Already-loaded reply cards must collapse.
+    rerender(
+      <Wrap filter={{ ...baseFilter, contentBelongTo: ['post'] }}>
+        <Timeline user="foo" />
+      </Wrap>,
+    );
+
+    await waitFor(() => expect(screen.queryAllByTestId('tcard')).toHaveLength(2));
+  });
+});


### PR DESCRIPTION
## Summary
- Subtle bug: when the active filter (e.g. *posts only*) collapses every `LoadableTCard` on the current page to `null`, the timeline has nothing scrollable. `react-infinite-scroll-component` only fires `next()` on scroll, so it never advances and the user sees an empty page even though more cdx items exist.
- Fix: watch the timeline container; whenever its bottom is within the viewport and `hasMore` is true, pull the next page. `ResizeObserver` handles the post-load collapse path (cards mount as skeletons, then shrink to `null` once filter mismatch is detected).
- Bonus test pins the related "filter change re-syncs already-loaded cards" behaviour, which turned out to already work via `useCachedFetch`'s `setData` dep.

## Test plan
- [x] `yarn vitest run tests/unit/Timeline.test.tsx` — 2 passed
- [x] `yarn vitest run` — 40 passed
- [x] `yarn build` — clean
- [ ] Manual: visit a heavy-reply user with content filter set to *posts only*, confirm the timeline keeps advancing rather than stalling on an empty viewport.

🤖 Generated with [Claude Code](https://claude.com/claude-code)